### PR TITLE
typo in dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Output:
 ## Dependencies
 
 ```sh
-apt install python3-pytz python3-unidecode python3-markdown python3-toml \
+apt install python3-tz python3-unidecode python3-markdown python3-toml \
             python3-yaml python3-jinja2 python3-dateutil python3-livereload
 ```
 

--- a/debian/control
+++ b/debian/control
@@ -8,7 +8,7 @@ Build-Depends: debhelper (>= 9),
                python3-setuptools,
 	       python3-unidecode, python3-markdown, python3-toml, python3-yaml,
 	       python3-jinja2, python3-dateutil, python3-livereload,
-               python3-pytz
+               python3-tz
 Build-Depends-Indep: help2man
 Standards-Version: 3.9.7
 Vcs-Git: https://github.com/spanezz/staticsite.git


### PR DESCRIPTION
Fixes python3-pytz ->  python3-tz dependency in both readme and debian packaging.