### PR TITLE
Repo mode

### DIFF
--- a/doc/settings.md
+++ b/doc/settings.md
@@ -7,7 +7,7 @@ is interpreted via Python similarly to what happens in
 Only uppercase settings are used.
 
 Default settings are defined in the module `staticsite/global_settings.py` and
-overridden by `settings.py`.
+overridden by `settings.py` or `.staticsite.py`.
 
 ## Common settings
 

--- a/example/content/.secret
+++ b/example/content/.secret
@@ -1,0 +1,1 @@
+This should not end up in the web directory.

--- a/example/content/.secrets/page.md
+++ b/example/content/.secrets/page.md
@@ -1,0 +1,1 @@
+This should not end up in the web directory.

--- a/example/content/pages/README.md
+++ b/example/content/pages/README.md
@@ -1,0 +1,3 @@
+# This is an example site
+
+[Docs](doc/sub.md)

--- a/example/content/pages/README.md
+++ b/example/content/pages/README.md
@@ -1,3 +1,5 @@
 # This is an example site
 
 [Docs](doc/sub.md)
+
+[Back home](..)

--- a/example/content/pages/doc/sub.md
+++ b/example/content/pages/doc/sub.md
@@ -1,0 +1,3 @@
+# Documentation
+
+[Back to README](../README.md)

--- a/staticsite/commands.py
+++ b/staticsite/commands.py
@@ -43,6 +43,11 @@ class SiteCommand:
 
         self.settings = Settings()
 
+        # "Repo mode", adjust paths if README.md exists in the root
+        if os.path.isfile(os.path.join(self.root, 'README.md')):
+                self.settings.CONTENT = self.root
+                self.settings.OUTPUT = self.root + '.site.out'
+
         # Load settings (optional)
         settings_files = (os.path.join(self.root, f) for f in settings_files)
         settings_file = next(filter(os.path.isfile, settings_files), None)

--- a/staticsite/commands.py
+++ b/staticsite/commands.py
@@ -27,24 +27,27 @@ class SiteCommand:
 
         self.setup_logging(args)
 
+        settings_files = ['settings.py', '.staticsite.py']
+
         # Default to current directory if project was not provided.
         # If the project was provided and is a .py file, load it as settings.
         if args.project:
             if os.path.isfile(args.project) and args.project.endswith(".py"):
-                self.settings_abspath = os.path.abspath(args.project)
-                self.root = os.path.dirname(self.settings_abspath)
+                settings_file = os.path.abspath(args.project)
+                self.root, settings_file = os.path.split(settings_file)
+                settings_files.insert(0, settings_file)
             else:
                 self.root = os.path.abspath(args.project)
-                self.settings_abspath = os.path.join(self.root, "settings.py")
         else:
             self.root = os.getcwd()
-            self.settings_abspath = os.path.join(self.root, "settings.py")
 
         self.settings = Settings()
 
         # Load settings (optional)
-        if os.path.isfile(self.settings_abspath):
-            self.settings.load(self.settings_abspath)
+        settings_files = (os.path.join(self.root, f) for f in settings_files)
+        settings_file = next(filter(os.path.isfile, settings_files), None)
+        if settings_file:
+            self.settings.load(settings_file)
 
         # Command line overrides for settings
         if self.args.theme: self.settings.THEME = os.path.abspath(self.args.theme)

--- a/staticsite/core.py
+++ b/staticsite/core.py
@@ -164,6 +164,8 @@ class Page:
         root = os.path.dirname(self.src_relpath)
         while True:
             target_relpath = os.path.normpath(os.path.join(root, target))
+            if target_relpath == ".":
+                target_relpath = ""
             res = self.site.pages.get(target_relpath, None)
             if res is not None: return res
             if not root or root == "/":

--- a/staticsite/markdown.py
+++ b/staticsite/markdown.py
@@ -51,7 +51,7 @@ class LinkResolver(markdown.treeprocessors.Treeprocessor):
         # Also allow .md extension in
         if dest is None and parsed.path.endswith(".md"):
             dirname, basename = os.path.split(parsed.path)
-            if basename == "index.md":
+            if basename in ("index.md", "README.md"):
                 dest = self.page.resolve_link(dirname)
             else:
                 dest = self.page.resolve_link(parsed.path[:-3])
@@ -202,7 +202,7 @@ class MarkdownPage(Page):
 
     def __init__(self, mdenv, root_abspath, relpath):
         dirname, basename = os.path.split(relpath)
-        if basename == "index.md":
+        if basename in ("index.md", "README.md"):
             linkpath = dirname
         else:
             linkpath = os.path.splitext(relpath)[0]

--- a/staticsite/site.py
+++ b/staticsite/site.py
@@ -95,6 +95,10 @@ class Site:
         log.info("Loading pages from %s", tree_root)
 
         for root, dnames, fnames in os.walk(tree_root):
+            for i, d in enumerate(dnames):
+                if d.startswith("."):
+                    del dnames[i]
+
             for f in fnames:
                 if f.startswith("."): continue
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,40 @@
+# coding: utf-8
+from unittest import TestCase
+from staticsite.build import Build
+from . import example_site, TestArgs
+import os
+
+class TestConfigfile(TestCase):
+    def _test_project(self, root, title='Example web site', cfg=''):
+        args = TestArgs(project=root + cfg)
+        build = Build(args)
+        build.run()
+
+        output = os.path.join(root, "web/index.html")
+        self.assertTrue(os.path.exists(output))
+
+        with open(output, "rt") as fd:
+            content = fd.read()
+
+        self.assertIn(title, content)
+
+    def test_default_name(self):
+        with example_site() as root:
+            self._test_project(root)
+
+    def test_alt_name(self):
+        with example_site() as root:
+            os.rename(os.path.join(root, 'settings.py'),
+                      os.path.join(root, '.staticsite.py'))
+            self._test_project(root)
+
+    def test_custom_name(self):
+        with example_site() as root:
+            os.rename(os.path.join(root, 'settings.py'),
+                      os.path.join(root, 'otherconfig.py'))
+            self._test_project(root, cfg='/otherconfig.py')
+
+    def test_no_config(self):
+        with example_site() as root:
+            os.remove(os.path.join(root, 'settings.py'))
+            self._test_project(root, title='Site name not set')

--- a/tests/test_site.py
+++ b/tests/test_site.py
@@ -90,3 +90,19 @@ class TestBuild(TestCase):
             output = os.path.join(root, "web/.secrets")
             self.assertFalse(os.path.exists(output))
 
+    def test_different_index(self):
+        with example_site() as root:
+            args = TestArgs(project=root)
+            build = Build(args)
+            build.run()
+
+            output = os.path.join(root, "web/pages/index.html")
+            with open(output, "rt") as fd:
+                content = fd.read()
+            self.assertIn('<a href="/pages/doc/sub">Docs</a>', content)
+
+            output = os.path.join(root, "web/pages/doc/sub/index.html")
+            with open(output, "rt") as fd:
+                content = fd.read()
+            self.assertIn('<a href="/pages">Back to README</a>', content)
+

--- a/tests/test_site.py
+++ b/tests/test_site.py
@@ -1,5 +1,6 @@
 # coding: utf-8
 from unittest import TestCase
+from staticsite.build import Build
 from staticsite.site import Site
 from staticsite.core import Page
 from . import datafile_abspath, example_site, TestArgs
@@ -66,7 +67,6 @@ class TestMarkdownInJinja2(TestCase):
             with open(page, "wt") as fd:
                 fd.write("{% filter markdown %}*This* is an [example](http://example.org){% endfilter %}")
 
-            from staticsite.build import Build
             args = TestArgs(project=root)
             build = Build(args)
             build.run()
@@ -77,3 +77,16 @@ class TestMarkdownInJinja2(TestCase):
                 content = fd.read()
 
             self.assertEqual(content, '<p><em>This</em> is an <a href="http://example.org">example</a></p>')
+
+class TestBuild(TestCase):
+    def test_dots(self):
+        with example_site() as root:
+            args = TestArgs(project=root)
+            build = Build(args)
+            build.run()
+
+            output = os.path.join(root, "web/.secret")
+            self.assertFalse(os.path.exists(output))
+            output = os.path.join(root, "web/.secrets")
+            self.assertFalse(os.path.exists(output))
+

--- a/tests/test_site.py
+++ b/tests/test_site.py
@@ -90,7 +90,7 @@ class TestBuild(TestCase):
             output = os.path.join(root, "web/.secrets")
             self.assertFalse(os.path.exists(output))
 
-    def test_different_index(self):
+    def test_different_links(self):
         with example_site() as root:
             args = TestArgs(project=root)
             build = Build(args)
@@ -100,9 +100,9 @@ class TestBuild(TestCase):
             with open(output, "rt") as fd:
                 content = fd.read()
             self.assertIn('<a href="/pages/doc/sub">Docs</a>', content)
+            self.assertIn('<a href="/">Back home</a>', content)
 
             output = os.path.join(root, "web/pages/doc/sub/index.html")
             with open(output, "rt") as fd:
                 content = fd.read()
             self.assertIn('<a href="/pages">Back to README</a>', content)
-


### PR DESCRIPTION
This branch implements the changes I proposed in #4. There are 2 bug fixes here (dot directories, relative links to root), I can split them out to another pull request if some commits need more discussion.

The nice thing about these changes: You can now point `ssite server` to any directory with a README.md and get served a live markdown preview :)

One thing I just realized: If there is a index.md and README.md in the same directory, one of those files gets ignored, maybe one should probably win and the other should just work like a "normal" file...