### PR TITLE
Allow markdown extensions to be configured in settings

### DIFF
--- a/doc/settings.md
+++ b/doc/settings.md
@@ -54,6 +54,14 @@ EDITOR = os.environ.get("EDITOR", "sensible-editor")
 # Each list element is expanded with string.format. All settings are available
 # for expansion, and {name} is the absolute path of the file to edit.
 EDIT_COMMAND = ["{EDITOR}", "{name}"]
+
+# extensions for python-markdown and their config used for this site
+MARKDOWN_EXTENSIONS = [
+    "markdown.extensions.extra",
+    "markdown.extensions.codehilite",
+    "markdown.extensions.fenced_code",
+]
+MARKDOWN_EXTENSION_CONFIGS = {}
 ```
 
 [Back to README](../README.md)

--- a/staticsite/global_settings.py
+++ b/staticsite/global_settings.py
@@ -32,3 +32,11 @@ EDITOR = os.environ.get("EDITOR", "sensible-editor")
 # Each list element is expanded with string.format. All settings are available
 # for expansion, and {name} is the absolute path of the file to edit.
 EDIT_COMMAND = ["{EDITOR}", "{name}", "+"]
+
+# extensions for python-markdown and their config used for this site
+MARKDOWN_EXTENSIONS = [
+    "markdown.extensions.extra",
+    "markdown.extensions.codehilite",
+    "markdown.extensions.fenced_code",
+]
+MARKDOWN_EXTENSION_CONFIGS = {}

--- a/staticsite/markdown.py
+++ b/staticsite/markdown.py
@@ -84,12 +84,10 @@ class MarkdownPages:
         self.site = site
         self.md_staticsite = StaticSiteExtension()
         self.markdown = markdown.Markdown(
-            extensions=[
-                "markdown.extensions.extra",
-                "markdown.extensions.codehilite",
-                "markdown.extensions.fenced_code",
+            extensions=site.settings.MARKDOWN_EXTENSIONS + [
                 self.md_staticsite,
             ],
+            extension_configs=site.settings.MARKDOWN_EXTENSION_CONFIGS,
             output_format="html5",
         )
         # Cached templates


### PR DESCRIPTION
As the title says this small change allows to add/remove python-markdown extensions via project settings and fiddle with their configuration instead of hardcoding this in staticsite internals.

(This change lingers on my systems for a while now doing its small job there… sorry for not proposing this sooner)