### PR TITLE
Allow sorting pages by destination url

### DIFF
--- a/doc/templates.md
+++ b/doc/templates.md
@@ -30,8 +30,9 @@ Extra functions provided to Jinja2 templates:
  * `site_pages(path=None, limit=None, sort="-date")`: return a list of pages
    defined in the site that match the given arguments. `path` is a file glob
    (like `"blog/*"`) that matches the page file name. `limit` is the maximum
-   number of pages to return. `sort` is the `page.meta` field to use to sort
-   the pages. Prefix `sort` with a dash (`-`) for reverse sorting.
+   number of pages to return. `sort` is either the `page.meta` field or the
+   keyword `url` for the destination link of the page to use to sort the pages.
+   Prefix `sort` with a dash (`-`) for reverse sorting.
             now=self.generation_time,
  * `now`: the current date and time.
  * `next_month`: midnight of the first day of next month. Useful in archetypes

--- a/staticsite/theme.py
+++ b/staticsite/theme.py
@@ -108,11 +108,15 @@ class Theme:
         for page in self.site.pages.values():
             if not page.FINDABLE: continue
             if re_path is not None and not re_path.match(page.src_relpath): continue
-            if sort is not None and sort not in page.meta: continue
+            if sort is not None and sort != "url" and sort not in page.meta: continue
             pages.append(page)
 
         if sort is not None:
-            pages.sort(key=lambda p: p.meta.get(sort, None), reverse=sort_reverse)
+            if sort == "url":
+                sort_by = lambda p: p.dst_link
+            else:
+                sort_by = lambda p: p.meta.get(sort, None)
+            pages.sort(key=sort_by, reverse=sort_reverse)
 
         if limit is not None:
             pages = pages[:limit]


### PR DESCRIPTION
Lets say you have a sort-of diary/notes/junkyard with the filelayout `diary/<year>/<month>/<day>.md`.

Directory listing only shows the contents of individual months, but if you want an index of all entries sorted to have the most recent at the top you have a problem: As your diary pre-dates ssite/is (not) auto-generated/… those files have no header to speak of (so not sortable by date) and there is also no established title format you could sort by (if they have a title at all). The only thing they can be reasonably be sorted by seems to be the URL of the entry.

So this PR introduces the `url` keyword to be able to sort by the dst_link of a page rather than any (non-existent) meta data. Your problem is hence solved by `{% for page in site_pages(path="diary/*/*/*", sort="-url") %}`.