### PR TITLE
Allow to pass strings as datetime and format to datetime_format

### DIFF
--- a/doc/templates.md
+++ b/doc/templates.md
@@ -42,7 +42,9 @@ Extra filters provided to Jinja2 templates:
 
  * `|datetime_format(format=None)` formats a datetime. Formats
    supported: "rss2", "rfc822", "atom", "rfc3339", "w3ctdf",
-   "[iso8601](https://xkcd.com/1179/)" (default).
+   "[iso8601](https://xkcd.com/1179/)" (default). If the format
+   starts with `%` it is considered a [strftime](http://strftime.org/)
+   format string.
  * `basename` returns the file name part of a pathname.
  * `markdown` renders the string using [markdown](markdown.md).
 

--- a/staticsite/theme.py
+++ b/staticsite/theme.py
@@ -71,6 +71,8 @@ class Theme:
         elif format == "iso8601" or not format:
             from .utils import format_date_iso8601
             return format_date_iso8601(dt)
+        elif format[0] == '%':
+            return dt.strftime(format)
         else:
             log.warn("%s+%s: invalid datetime format %r requested", context.parent["page"].src_relpath, context.name, format)
             return "(unknown datetime format {})".format(format)

--- a/staticsite/theme.py
+++ b/staticsite/theme.py
@@ -56,6 +56,9 @@ class Theme:
 
     @jinja2.contextfilter
     def jinja2_datetime_format(self, context, dt, format=None):
+        if not isinstance(dt, datetime.datetime):
+            import dateutil.parser
+            dt = dateutil.parser.parse(dt)
         if format in ("rss2", "rfc822"):
             from .utils import format_date_rfc822
             return format_date_rfc822(dt)


### PR DESCRIPTION
My (main) usecase: I have a sort-of timeline formatted by a jinja2 macro. The job of the macro is to format the entries in some nice way (FSVO nice) including formatting dates in a human-friendly way (and annotated for machines). The data entry on the other hand is via calls to this macro: Here, I would like to use a machine-friendly date format and not hardcode another human friendly version, hence I would like to feed the machine-friendly format in the macro into `datetime_format` and get out the human friendly version I desire (at the moment. If I change my mind its a single line change).

So the macro might include something like this: `<time datetime="{{ starttime }}">{{ starttime | datetime_format('%Y<br/>%b')|safe }}</time>` where `starttime` is `2018-06-03 13:51+0200`.

Dealing with hardcoded datestrings is perhaps a bit specialcasey (but easy enough, so I propose it anyway), but allowing arbitrary format strings seems like something nice to have if you don't believe in [standards](https://xkcd.com/927/).