### PR TITLE
Fix example in taxonomies documentation

### DIFF
--- a/doc/taxonomies.md
+++ b/doc/taxonomies.md
@@ -42,9 +42,9 @@ template_archive = "tag-archive.html"
 template_atom = "tag.atom"
 template_rss = "tag.rss"
 
-# When pages are added with these items of this taxonomy, also add them to a
-series with the same name as the tag
-series = ["links", "songs"]
+# When pages are added with these items of this taxonomy,
+# also add them to a series with the same name as the tag
+series_tags = ["links", "songs"]
 +++
 ```
 


### PR DESCRIPTION
The metadata tagname was changed as it conflicts with Series,
but the documentation wasn't updated. Also fix the wrapping of
the associated comment.

References: 1f93fa77eced42a42c703000ae826d75d68f2815

(composed via editing file directly in github… which seems handy & fast, but also feels super-strange and kinda dirty to be honest)