### PR TITLE
Follow links while directory walking

### DIFF
--- a/staticsite/archetypes.py
+++ b/staticsite/archetypes.py
@@ -40,7 +40,7 @@ class Archetypes:
 
         Returns None if nothing matches.
         """
-        for root, dnames, fnames in os.walk(self.root):
+        for root, dnames, fnames in os.walk(self.root,followlinks=True):
             for f in fnames:
                 if f.startswith("."):
                     continue

--- a/staticsite/site.py
+++ b/staticsite/site.py
@@ -175,7 +175,7 @@ class Site:
 
         log.info("Loading pages from %s", tree_root)
 
-        for root, dnames, fnames in os.walk(tree_root):
+        for root, dnames, fnames in os.walk(tree_root,followlinks=True):
             for i, d in enumerate(dnames):
                 if d.startswith("."):
                     del dnames[i]
@@ -211,7 +211,7 @@ class Site:
 
         log.info("Loading assets from %s", search_root)
 
-        for root, dnames, fnames in os.walk(search_root):
+        for root, dnames, fnames in os.walk(search_root,followlinks=True):
             for f in fnames:
                 if f.startswith("."):
                     continue


### PR DESCRIPTION
This allows e.g. "static" content like JS/CSS to be pulled in from a
third party location like /usr/share/javascript/ to avoid embedded
copies in the project (at the expense of potential breakage) or sharing
mostly static content pages like inprints between (sub)projects.

Building the site creates copies in the build directory as expected.