### PR TITLE
Adapt to Jinja 3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ setup(
     install_requires=[
         'markdown', 'docutils',
         'toml', 'pyyaml', 'ruamel.yaml',
-        'jinja2', 'Pillow',
+        'jinja2>3', 'Pillow',
         'python_dateutil', 'python_slugify', 'pytz'],
 
     # http://setuptools.readthedocs.io/en/latest/setuptools.html#declaring-extras-optional-features-with-their-own-dependencies

--- a/staticsite/features/data.py
+++ b/staticsite/features/data.py
@@ -120,7 +120,7 @@ This is used to group data of the same type together, and to choose a
         for pages in self.by_type.values():
             pages.sort(key=lambda x: x.meta["date"])
 
-    @jinja2.contextfunction
+    @jinja2.pass_context
     def jinja2_data_pages(self, context, type, path=None, limit=None, sort=None, **kw):
         page_filter = PageFilter(self.site, path=path, limit=limit, sort=sort, **kw)
         return page_filter.filter(self.by_type.get(type, []))

--- a/staticsite/features/jinja2.py
+++ b/staticsite/features/jinja2.py
@@ -7,6 +7,7 @@ from staticsite.utils import front_matter
 from staticsite.page_filter import compile_page_match
 from staticsite.utils.typing import Meta
 import jinja2
+import markupsafe
 import os
 import logging
 
@@ -109,21 +110,21 @@ class RenderPartialTemplateMixin:
         log.warn("%s: `page_content` and `content` not found in template %s", self, self.page_template.name)
         return None, None
 
-    @jinja2.contextfunction
+    @jinja2.pass_context
     def html_body(self, context, **kw) -> str:
         block_name, block = self._find_block("page_content", "content")
         if block is None:
             return ""
         return self.render_template_block(block, block_name, context, render_style="body")
 
-    @jinja2.contextfunction
+    @jinja2.pass_context
     def html_inline(self, context, **kw) -> str:
         block_name, block = self._find_block("page_content", "content")
         if block is None:
             return ""
         return self.render_template_block(block, block_name, context, render_style="inline")
 
-    @jinja2.contextfunction
+    @jinja2.pass_context
     def html_feed(self, context, **kw) -> str:
         block_name, block = self._find_block("page_content", "content")
         if block is None:
@@ -145,7 +146,7 @@ class RenderPartialTemplateMixin:
         kw["page"] = self
 
         try:
-            return jinja2.Markup("".join(block(self.page_template.new_context(context, shared=True, locals=kw))))
+            return markupsafe.Markup("".join(block(self.page_template.new_context(context, shared=True, locals=kw))))
         except jinja2.TemplateError as e:
             log.error("%s: %s: failed to render block %s: %s", self, self.page_template.filename, block_name, e)
             log.debug("%s: %s: failed to render block %s: %s",

--- a/staticsite/features/links/__init__.py
+++ b/staticsite/features/links/__init__.py
@@ -150,7 +150,7 @@ It is a list of dicts of metadata, one for each link. In each dict, these keys a
             meta = {}
         return meta
 
-    @jinja2.contextfunction
+    @jinja2.pass_context
     def links_merged(self, context, path=None, limit=None, sort=None, link_tags=None, **kw):
         page_filter = PageFilter(self.site, path=path, limit=limit, sort=sort, **kw)
 
@@ -174,7 +174,7 @@ It is a list of dicts of metadata, one for each link. In each dict, these keys a
 
         return links
 
-    @jinja2.contextfunction
+    @jinja2.pass_context
     def links_tag_index_url(self, context, tag):
         dest = self.indices[0].by_tag[tag]
         page = context.parent["page"]

--- a/staticsite/features/markdown.py
+++ b/staticsite/features/markdown.py
@@ -8,6 +8,7 @@ from staticsite.contents import ContentDir
 from staticsite.utils.typing import Meta
 from urllib.parse import urlparse, urlunparse
 import jinja2
+import markupsafe
 import re
 import os
 import io
@@ -153,9 +154,9 @@ class MarkdownPages(Feature):
 
         self.render_cache = self.site.caches.get("markdown")
 
-    @jinja2.contextfilter
+    @jinja2.pass_context
     def jinja2_markdown(self, context, mdtext):
-        return jinja2.Markup(self.render_snippet(context.parent["page"], mdtext))
+        return markupsafe.Markup(self.render_snippet(context.parent["page"], mdtext))
 
     def render_page(self, page: Page, body: List[str], render_type: str, absolute: bool = False):
         """
@@ -368,7 +369,7 @@ class MarkdownPage(Page):
     def check(self, checker):
         self.render()
 
-    @jinja2.contextfunction
+    @jinja2.pass_context
     def html_body(self, context, **kw) -> str:
         absolute = self != context["page"]
         if self.content_has_split:
@@ -377,7 +378,7 @@ class MarkdownPage(Page):
         else:
             return self.mdpages.render_page(self, self.body_start, render_type="s", absolute=absolute)
 
-    @jinja2.contextfunction
+    @jinja2.pass_context
     def html_inline(self, context, **kw) -> str:
         absolute = self != context["page"]
         if self.content_has_split:
@@ -386,7 +387,7 @@ class MarkdownPage(Page):
         else:
             return self.mdpages.render_page(self, self.body_start, render_type="s", absolute=absolute)
 
-    @jinja2.contextfunction
+    @jinja2.pass_context
     def html_feed(self, context, **kw) -> str:
         absolute = self != context["page"]
         if self.content_has_split:

--- a/staticsite/features/rst.py
+++ b/staticsite/features/rst.py
@@ -295,15 +295,15 @@ class RstPage(Page):
         # })
         return parts["body"]
 
-    @jinja2.contextfunction
+    @jinja2.pass_context
     def html_body(self, context, **kw) -> str:
         return self._render_page()
 
-    @jinja2.contextfunction
+    @jinja2.pass_context
     def html_inline(self, context, **kw) -> str:
         return self._render_page()
 
-    @jinja2.contextfunction
+    @jinja2.pass_context
     def html_feed(self, context, **kw) -> str:
         return self._render_page()
 

--- a/staticsite/features/syndication.py
+++ b/staticsite/features/syndication.py
@@ -134,7 +134,7 @@ If a page is syndicated and `syndication_date` is missing, it defaults to `date`
 
         self.j2_globals["syndicated_pages"] = self.jinja2_syndicated_pages
 
-    @jinja2.contextfunction
+    @jinja2.pass_context
     def jinja2_syndicated_pages(self, context, what: Union[str, Page, List[Page], None] = None, limit=None) -> bool:
         """
         Get the list of pages to be syndicated

--- a/staticsite/metadata.py
+++ b/staticsite/metadata.py
@@ -235,7 +235,7 @@ class MetadataTemplateInherited(Metadata):
         """
         Hook for inheriting metadata entries from a parent page
         """
-        import jinja2
+        import markupsafe
 
         # If template_for exists, no need to render anything
         if self.template_for in page.meta:
@@ -257,7 +257,7 @@ class MetadataTemplateInherited(Metadata):
         if isinstance(src, str):
             src = self.site.theme.jinja2.from_string(src)
 
-        page.meta[self.template_for] = jinja2.Markup(page.render_template(src))
+        page.meta[self.template_for] = markupsafe.Markup(page.render_template(src))
 
     def on_dir_meta(self, page: Page, meta: Meta):
         """

--- a/staticsite/page.py
+++ b/staticsite/page.py
@@ -7,6 +7,7 @@ from .utils import lazy
 from .utils.typing import Meta
 from .render import RenderedString
 import jinja2
+import markupsafe
 
 if TYPE_CHECKING:
     from .site import Site
@@ -316,11 +317,11 @@ class Page:
                     continue
 
                 url = self.url_for(rel, absolute=absolute)
-                srcsets.append(f"{jinja2.escape(url)} {width}w")
+                srcsets.append(f"{markupsafe.escape(url)} {width}w")
 
             if srcsets:
                 width = img.meta["width"]
-                srcsets.append(f"{jinja2.escape(self.url_for(img))} {width}w")
+                srcsets.append(f"{markupsafe.escape(self.url_for(img))} {width}w")
                 res["srcset"] = ", ".join(srcsets)
                 res["src"] = self.url_for(img, absolute=absolute)
             else:
@@ -348,7 +349,7 @@ class Page:
         else:
             return f"{self.TYPE}:auto:{self.meta['site_path']}"
 
-    @jinja2.contextfunction
+    @jinja2.pass_context
     def html_full(self, context, **kw) -> str:
         """
         Render the full page, from the <html> tag downwards.
@@ -358,7 +359,7 @@ class Page:
         context.update(kw)
         return self.render_template(self.page_template, template_args=context)
 
-    @jinja2.contextfunction
+    @jinja2.pass_context
     def html_body(self, context, **kw) -> str:
         """
         Render the full body of the page, with UI elements excluding
@@ -366,7 +367,7 @@ class Page:
         """
         return ""
 
-    @jinja2.contextfunction
+    @jinja2.pass_context
     def html_inline(self, context, **kw) -> str:
         """
         Render the content of the page to be shown inline, like in a blog page.
@@ -375,7 +376,7 @@ class Page:
         """
         return ""
 
-    @jinja2.contextfunction
+    @jinja2.pass_context
     def html_feed(self, context, **kw) -> str:
         """
         Render the content of the page to be shown in a RSS/Atom feed.

--- a/staticsite/theme.py
+++ b/staticsite/theme.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 from typing import List, Optional, Union, Sequence, Dict, Set
 import jinja2
+import markupsafe
 import os
 import re
 import datetime
@@ -331,7 +332,7 @@ class Theme:
     def jinja2_basename(self, val: str) -> str:
         return os.path.basename(val)
 
-    @jinja2.contextfilter
+    @jinja2.pass_context
     def jinja2_datetime_format(self, context, dt: datetime.datetime, format: str = None) -> str:
         if not isinstance(dt, datetime.datetime):
             import dateutil.parser
@@ -355,7 +356,7 @@ class Theme:
                      context.parent["page"].src.relpath, context.name, format)
             return "(unknown datetime format {})".format(format)
 
-    @jinja2.contextfunction
+    @jinja2.pass_context
     def jinja2_has_page(self, context, arg: str) -> bool:
         cur_page = context.get("page")
         try:
@@ -365,7 +366,7 @@ class Theme:
         else:
             return True
 
-    @jinja2.contextfunction
+    @jinja2.pass_context
     def jinja2_page_for(self, context, arg: Union[str, Page]) -> Page:
         """
         Generate a URL for a page, specified by path or with the page itself
@@ -384,7 +385,7 @@ class Theme:
             log.warn("%s:%s: %s", cur_page, context.name, e)
             return ""
 
-    @jinja2.contextfunction
+    @jinja2.pass_context
     def jinja2_url_for(self, context, arg: Union[str, Page], absolute=False) -> str:
         """
         Generate a URL for a page, specified by path or with the page itself
@@ -400,7 +401,7 @@ class Theme:
             log.warn("%s:%s: %s", cur_page, context.name, e)
             return ""
 
-    @jinja2.contextfunction
+    @jinja2.pass_context
     def jinja2_site_pages(self, context, **kw) -> List[Page]:
         cur_page = context.get("page")
         if cur_page is None:
@@ -409,7 +410,7 @@ class Theme:
 
         return cur_page.find_pages(**kw)
 
-    @jinja2.contextfunction
+    @jinja2.pass_context
     def jinja2_img_for(
             self, context,
             path: Union[str, Page],
@@ -424,9 +425,9 @@ class Theme:
         res_attrs = cur_page.get_img_attributes(path, type=type, absolute=absolute)
         res_attrs.update(attrs)
 
-        escape = jinja2.escape
+        escape = markupsafe.escape
         res = ["<img"]
         for k, v in res_attrs.items():
             res.append(f" {escape(k)}='{escape(v)}'")
         res.append("></img>")
-        return jinja2.Markup("".join(res))
+        return markupsafe.Markup("".join(res))


### PR DESCRIPTION
It seems most errors could be fixed with simple search-and-replace.
The old names were already deprecated with Jinja 3.0 (2021-05-11), but
finally removed with Jinja 3.1 (2022-03-24).

I did only light testing, but all tests still pass.